### PR TITLE
fix: overflow in function CreateDataPoint

### DIFF
--- a/packages/protocol/src/redstone-payload/RedstonePayloadParser.ts
+++ b/packages/protocol/src/redstone-payload/RedstonePayloadParser.ts
@@ -1,5 +1,5 @@
 import { BigNumber } from "ethers";
-import { hexlify, toUtf8String } from "ethers/lib/utils";
+import { formatUnits, hexlify, toUtf8String } from "ethers/lib/utils";
 import {
   DATA_FEED_ID_BS,
   DATA_PACKAGES_COUNT_BS,
@@ -161,7 +161,7 @@ export class RedstonePayloadParser {
   ): DataPoint {
     return new NumericDataPoint({
       dataFeedId: toUtf8String(dataFeedId).replaceAll("\x00", ""),
-      value: BigNumber.from(dataPointValue).toNumber() / 10 ** 8,
+      value: Number(formatUnits(BigNumber.from(dataPointValue), 8)),
     });
   }
 


### PR DESCRIPTION
We also need to change parse-redstone-payload.js (28th line) to:
console.log("Data points values: ", signedDataPackage.dataPackage.dataPoints.map(dp => BigNumber.from(dp.value).toString()));

or any other method that don't call toNumber, because of possible overflow