### PR TITLE
feat: allow only ccxt updates (security updates will be still working)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,12 +6,4 @@ updates:
       interval: "daily"
     open-pull-requests-limit: 3
     allow:
-      - dependency-name: "*"
-        update-types: ["version-update:semver-patch"]
       - dependency-name: "ccxt"
-        update-types:
-          [
-            "version-update:semver-patch",
-            "version-update:semver-major",
-            "version-update:semver-minor",
-          ]


### PR DESCRIPTION
I wasn't able to enable minor and major updates only on cctx. Cause:
```
You can use allow and ignore to customize which dependencies to maintain. Dependabot checks for all allowed dependencies and then filters out any ignored dependencies or versions. So a dependency that is matched by both an allow and an ignore will be ignored.
```
So I think there will be more value if add here packages that we really want to update like `ccxt`. 
Security updates are still working as they were working (on all packages) we edit here only "normal" updates.
