### PR TITLE
feat: Add more logs to on-chain-relayer

### DIFF
--- a/packages/on-chain-relayer/src/core/contract-interactions/update-prices.ts
+++ b/packages/on-chain-relayer/src/core/contract-interactions/update-prices.ts
@@ -37,7 +37,12 @@ export const updatePrices = async (
   const minimalTimestamp = Math.min(...dataPackagesTimestamps);
 
   if (lastUpdateTimestamp >= minimalTimestamp) {
-    console.log("Cannot update prices, proposed prices are not newer");
+    console.log(
+      `Cannot update prices, proposed prices are not newer ${JSON.stringify({
+        lastUpdateTimestamp,
+        dataPackageTimestamp: minimalTimestamp,
+      })}`
+    );
   } else {
     const wrapContract = (adapterContract: Contract) =>
       WrapperBuilder.wrap(adapterContract).usingDataPackages(dataPackages);

--- a/packages/on-chain-relayer/src/core/update-conditions/should-update.ts
+++ b/packages/on-chain-relayer/src/core/update-conditions/should-update.ts
@@ -15,6 +15,13 @@ export const shouldUpdate = (context: Context): ConditionCheckResponse => {
       warningMessages.push(conditionCheck.warningMessage);
     }
   }
+
+  console.log(
+    `Update condition ${
+      shouldUpdatePrices ? "" : "NOT"
+    } satisfied: ${warningMessages.join("; ")}`
+  );
+
   return {
     shouldUpdatePrices,
     warningMessage: JSON.stringify(warningMessages),

--- a/packages/on-chain-relayer/src/core/update-conditions/time-condition.ts
+++ b/packages/on-chain-relayer/src/core/update-conditions/time-condition.ts
@@ -5,10 +5,14 @@ export const timeUpdateCondition = (lastUpdateTimestamp: number) => {
   const currentTimestamp = Date.now();
   const timeDiff = currentTimestamp - lastUpdateTimestamp;
   const shouldUpdatePrices = timeDiff >= updatePriceInterval;
+  const logTrace = JSON.stringify({
+    timeDiff,
+    updatePriceInterval,
+  });
   return {
     shouldUpdatePrices,
     warningMessage: shouldUpdatePrices
-      ? ""
-      : "Not enough time has passed to update prices",
+      ? `Enough time passed to updated prices: ${logTrace}`
+      : `Not enough time has passed to update prices: ${logTrace}`,
   };
 };

--- a/packages/on-chain-relayer/src/core/update-conditions/value-deviation-condition.ts
+++ b/packages/on-chain-relayer/src/core/update-conditions/value-deviation-condition.ts
@@ -32,7 +32,7 @@ export const valueDeviationCondition = (
         );
 
         logTrace.addPerDataFeedLog(
-          dataFeedId,
+          dataPackage.timestampMilliseconds,
           valueFromContractAsDecimal,
           dataPackages[dataFeedId].length,
           dataPointObj
@@ -78,7 +78,7 @@ class ValueDeviationLogTrace {
     {
       valueFromContract: number;
       valuesFromNode: number[];
-      timestamp?: number;
+      timestamp: number;
       packagesCount: number;
     }
   > = {};
@@ -86,29 +86,22 @@ class ValueDeviationLogTrace {
   private thresholdDeviation!: string;
 
   addPerDataFeedLog(
-    dataFeedId: string,
+    timestamp: number,
     valueFromContract: number,
     packagesCount: number,
     dataPoint: INumericDataPoint
   ) {
+    const dataFeedId = dataPoint.dataFeedId;
     if (!this.perDataFeedId[dataFeedId]) {
       this.perDataFeedId[dataFeedId] = {
         valueFromContract: valueFromContract,
         valuesFromNode: [dataPoint.value],
         packagesCount,
+        timestamp,
       };
     } else {
       this.perDataFeedId[dataFeedId].valuesFromNode.push(dataPoint.value);
     }
-  }
-
-  addValueFromNode(dataPoint: INumericDataPoint) {
-    const dataFeedId = dataPoint.dataFeedId;
-    this.perDataFeedId[dataFeedId].valuesFromNode.push(dataPoint.value);
-  }
-
-  setTimestamp(dataFeedId: string, timestamp: number) {
-    this.perDataFeedId[dataFeedId].timestamp = timestamp;
   }
 
   addDeviationInfo(maxDeviation: number, thresholdDeviation: number) {

--- a/packages/on-chain-relayer/src/run-relayer.ts
+++ b/packages/on-chain-relayer/src/run-relayer.ts
@@ -27,9 +27,10 @@ const runIteration = async () => {
     cacheServiceUrls
   );
 
-  const { lastUpdateTimestamp } =
-    await getLastRoundParamsFromContract(adapterContract);
-  
+  const { lastUpdateTimestamp } = await getLastRoundParamsFromContract(
+    adapterContract
+  );
+
   // We fetch latest values from contract only if we want to check value deviation
   let valuesFromContract = {};
   if (config.updateConditions.includes("value-deviation")) {
@@ -39,20 +40,15 @@ const runIteration = async () => {
     );
   }
 
-  const { shouldUpdatePrices, warningMessage } = shouldUpdate({
+  const { shouldUpdatePrices } = shouldUpdate({
     dataPackages,
     valuesFromContract,
     lastUpdateTimestamp,
   });
 
   if (!shouldUpdatePrices) {
-    console.log(`All conditions are not fulfilled: ${warningMessage}`);
   } else {
-    await updatePrices(
-      dataPackages,
-      adapterContract,
-      lastUpdateTimestamp
-    );
+    await updatePrices(dataPackages, adapterContract, lastUpdateTimestamp);
   }
 
   await sendHealthcheckPing();
@@ -66,7 +62,8 @@ const task = new AsyncTask(
 
 const job = new SimpleIntervalJob(
   { milliseconds: relayerIterationInterval, runImmediately: true },
-  task
+  task,
+  { preventOverrun: true }
 );
 
 const scheduler = new ToadScheduler();

--- a/packages/on-chain-relayer/test/monorepo-integration-tests/scripts/verify-mock-prices.ts
+++ b/packages/on-chain-relayer/test/monorepo-integration-tests/scripts/verify-mock-prices.ts
@@ -10,7 +10,7 @@ import { PriceFeedsAdapterWithoutRounds } from "../../../typechain-types";
   );
   const contract: PriceFeedsAdapterWithoutRounds = ContractFactory.attach(
     process.env.ADAPTER_CONTRACT_ADDRESS ?? ""
-  );
+  ) as PriceFeedsAdapterWithoutRounds;
 
   console.log("adapter contract address", process.env.ADAPTER_CONTRACT_ADDRESS);
 

--- a/packages/on-chain-relayer/test/update-conditions/should-update.test.ts
+++ b/packages/on-chain-relayer/test/update-conditions/should-update.test.ts
@@ -25,11 +25,12 @@ describe("should-update", () => {
       lastUpdateTimestamp,
     });
     expect(shouldUpdatePrices).to.be.false;
-    expect(warningMessage).to.be.equal(
-      JSON.stringify([
-        "Not enough time has passed to update prices",
-        "Value has not deviated enough to be updated",
-      ])
+    expect(JSON.parse(warningMessage)[0]).to.match(
+      /Not enough time has passed to update prices/
+    );
+
+    expect(JSON.parse(warningMessage)[1]).to.match(
+      /Value has not deviated enough to/
     );
   });
 
@@ -46,8 +47,8 @@ describe("should-update", () => {
       lastUpdateTimestamp,
     });
     expect(shouldUpdatePrices).to.be.true;
-    expect(warningMessage).to.be.equal(
-      `["Not enough time has passed to update prices"]`
+    expect(JSON.parse(warningMessage)).to.match(
+      /Not enough time has passed to update prices/
     );
   });
 
@@ -64,8 +65,8 @@ describe("should-update", () => {
       lastUpdateTimestamp,
     });
     expect(shouldUpdatePrices).to.be.true;
-    expect(warningMessage).to.be.equal(
-      `["Value has not deviated enough to be updated"]`
+    expect(JSON.parse(warningMessage)).to.match(
+      /Value has not deviated enough to be updated/
     );
   });
 
@@ -86,8 +87,8 @@ describe("should-update", () => {
       valuesFromContract: sameValue,
       lastUpdateTimestamp,
     });
-    expect(warningMessage).to.be.equal(
-      `["Value has not deviated enough to be updated"]`
+    expect(warningMessage).to.match(
+      /Value has not deviated enough to be updated/
     );
   });
 
@@ -106,6 +107,6 @@ describe("should-update", () => {
       valuesFromContract: sameValue,
       lastUpdateTimestamp,
     });
-    expect(warningMessage).to.be.equal(`[]`);
+    expect(warningMessage).to.match(/Enough time passed to updated price/);
   });
 });

--- a/packages/on-chain-relayer/test/update-conditions/time-condition.test.ts
+++ b/packages/on-chain-relayer/test/update-conditions/time-condition.test.ts
@@ -12,8 +12,8 @@ describe("time-condition", () => {
     const { shouldUpdatePrices, warningMessage } =
       timeUpdateCondition(lastUpdateTimestamp);
     expect(shouldUpdatePrices).to.be.false;
-    expect(warningMessage).to.be.equal(
-      "Not enough time has passed to update prices"
+    expect(warningMessage).to.match(
+      /Not enough time has passed to update prices/
     );
   });
 
@@ -22,6 +22,6 @@ describe("time-condition", () => {
     const { shouldUpdatePrices, warningMessage } =
       timeUpdateCondition(lastUpdateTimestamp);
     expect(shouldUpdatePrices).to.be.true;
-    expect(warningMessage).to.be.equal("");
+    expect(warningMessage).to.match(/Enough time passed to updated prices/);
   });
 });

--- a/packages/on-chain-relayer/test/update-conditions/value-deviation-condition.test.ts
+++ b/packages/on-chain-relayer/test/update-conditions/value-deviation-condition.test.ts
@@ -23,8 +23,8 @@ describe("value-deviation-condition", () => {
       smallerValueDiff
     );
     expect(shouldUpdatePrices).to.be.false;
-    expect(warningMessage).to.be.equal(
-      "Value has not deviated enough to be updated"
+    expect(warningMessage).to.match(
+      /Value has not deviated enough to be updated/
     );
   });
 
@@ -39,6 +39,6 @@ describe("value-deviation-condition", () => {
       biggerValueDiff
     );
     expect(shouldUpdatePrices).to.be.true;
-    expect(warningMessage).to.be.equal("");
+    expect(warningMessage).to.match(/Value has deviated enough to be/);
   });
 });

--- a/packages/rpc-providers/src/TransactionDeliveryMan.ts
+++ b/packages/rpc-providers/src/TransactionDeliveryMan.ts
@@ -195,7 +195,7 @@ export class TransactionDeliveryMan {
 
     const fee = await gasOracle();
 
-    this.opts.logger(`getFees result ${JSON.stringify(fee, null, 2)}`);
+    this.opts.logger(`getFees result ${JSON.stringify(fee)}`);
 
     return fee;
   }
@@ -215,7 +215,7 @@ export class TransactionDeliveryMan {
 
     const fee = { maxFeePerGas, maxPriorityFeePerGas };
 
-    this.opts.logger(`getFees result ${JSON.stringify(fee, null, 2)}`);
+    this.opts.logger(`getFees result ${JSON.stringify(fee)}`);
 
     return fee;
   }


### PR DESCRIPTION
sample:
```bash
Starting contract prices updater with interval 10000
Update condition NOT satisfied: Not enough time has passed to update prices: {"timeDiff":70145,"updatePriceInterval":110000}; Value has not deviated enough to be updated. {"VST":{"valueFromContract":0.99367395,"valuesFromNode":[0.9936990950421556],"packagesCount":1},"maxDeviation":"0.0025","thresholdDeviation":"100.0000"}
Update condition NOT satisfied: Not enough time has passed to update prices: {"timeDiff":80107,"updatePriceInterval":110000}; Value has not deviated enough to be updated. {"VST":{"valueFromContract":0.99367395,"valuesFromNode":[0.9937484136657652],"packagesCount":1},"maxDeviation":"0.0075","thresholdDeviation":"100.0000"}
Update condition NOT satisfied: Not enough time has passed to update prices: {"timeDiff":90166,"updatePriceInterval":110000}; Value has not deviated enough to be updated. {"VST":{"valueFromContract":0.99367395,"valuesFromNode":[0.9936959208665944],"packagesCount":1},"maxDeviation":"0.0022","thresholdDeviation":"100.0000"}
```