### PR TITLE
fix: configure properly nestjs-pino to log proper error stack

### DIFF
--- a/packages/cache-service/src/main.ts
+++ b/packages/cache-service/src/main.ts
@@ -2,6 +2,7 @@ import { NestFactory } from "@nestjs/core";
 import { AppModule } from "./app.module";
 import { urlencoded, json } from "express";
 import { Logger } from "nestjs-pino";
+import { LoggerErrorInterceptor } from "nestjs-pino";
 import config from "./config";
 
 const REQUEST_SIZE_LIMIT = "50mb";
@@ -11,6 +12,7 @@ async function bootstrap() {
   app.use(json({ limit: REQUEST_SIZE_LIMIT }));
   app.use(urlencoded({ extended: true, limit: REQUEST_SIZE_LIMIT }));
   app.useLogger(app.get(Logger));
+  app.useGlobalInterceptors(new LoggerErrorInterceptor());
   app.enableCors();
   await app.listen(config.appPort);
 }


### PR DESCRIPTION
Old stack was always:
```
{"level":30,"time":1688032559136,"pid":43639,"hostname":"Michals-Laptop.local","req":{"id":6,"method":"POST","url":"/data-packages/bulk","query":{},"params":{"0":"data-packages/bulk"},"headers":{"host":"localhost:3000","accept-encoding":"gzip, deflate","connection":"keep-alive","content-length":"156","user-agent":"HTTPie/3.2.2","accept":"application/json, */*;q=0.5","content-type":"application/json"},"remoteAddress":"::1","remotePort":65496},"res":{"statusCode":500,"headers":{"x-powered-by":"Express","access-control-allow-origin":"*","content-type":"application/json; charset=utf-8","content-length":"52","etag":"W/\"34-rlKccw1E+/fV8niQk4oFitDfPro\""}},"err":{"type":"Error","message":"failed with status code 500","stack":"Error: failed with status code 500\n    at onResFinished (/Users/michalkonopka/github/redstone-oracles-monorepo/node_modules/pino-http/logger.js:110:39)\n    at ServerResponse.onResponseComplete (/Users/michalkonopka/github/redstone-oracles-monorepo/node_modules/pino-http/logger.js:173:14)\n    at ServerResponse.emit (node:events:525:35)\n    at onFinish (node:_http_outgoing:950:10)\n    at callback (node:internal/streams/writable:554:21)\n    at afterWrite (node:internal/streams/writable:499:5)\n    at afterWriteTick (node:internal/streams/writable:486:10)\n    at processTicksAndRejections (node:internal/process/task_queues:82:21)"},"responseTime":1,"msg":"request errored"}
```

new stack:
```
{"level":30,"time":1688032568002,"pid":46019,"hostname":"Michals-Laptop.local","req":{"id":1,"method":"POST","url":"/data-packages/bulk","query":{},"params":{"0":"data-packages/bulk"},"headers":{"host":"localhost:3000","accept-encoding":"gzip, deflate","connection":"keep-alive","content-length":"156","user-agent":"HTTPie/3.2.2","accept":"application/json, */*;q=0.5","content-type":"application/json"},"remoteAddress":"::1","remotePort":49152},"res":{"statusCode":500,"headers":{"x-powered-by":"Express","access-control-allow-origin":"*","content-type":"application/json; charset=utf-8","content-length":"52","etag":"W/\"34-rlKccw1E+/fV8niQk4oFitDfPro\""}},"err":{"type":"TypeError","message":"Cannot read properties of undefined (reading 'length')","stack":"TypeError: Cannot read properties of undefined (reading 'length')\n    at toUtf8Bytes (/Users/michalkonopka/github/redstone-oracles-monorepo/node_modules/@ethersproject/strings/src.ts/utf8.ts:210:29)\n    at Function.getDigestForData (/Users/michalkonopka/github/redstone-oracles-monorepo/packages/protocol/src/UniversalSigner.ts:15:41)\n    at Function.recoverSigner (/Users/michalkonopka/github/redstone-oracles-monorepo/packages/protocol/src/UniversalSigner.ts:27:36)\n    at DataPackagesService.verifyRequester (/Users/michalkonopka/github/redstone-oracles-monorepo/packages/cache-service/src/data-packages/data-packages.service.ts:356:28)\n    at DataPackagesController.addBulk (/Users/michalkonopka/github/redstone-oracles-monorepo/packages/cache-service/src/data-packages/data-packages.controller.ts:165:52)\n    at /Users/michalkonopka/github/redstone-oracles-monorepo/node_modules/@nestjs/core/router/router-execution-context.js:38:29\n    at processTicksAndRejections (node:internal/process/task_queues:96:5)"},"responseTime":16,"msg":"request errored"}
```