### PR TITLE
fix: remove ethers .stack from error

### DIFF
--- a/packages/rpc-providers/src/TxBrodcaster.ts
+++ b/packages/rpc-providers/src/TxBrodcaster.ts
@@ -107,12 +107,11 @@ export class MultiNodeTxBroadcaster implements TxBroadcaster {
       } catch (e) {
         const rpcUrl = getRpcUrl(provider);
         (e as { rpcUrl: string }).rpcUrl = rpcUrl;
-        logger(
-          `provider ${rpcUrl}: failed to broadcast tx: ${RedstoneCommon.stringifyError(
-            e
-          )}`
-        );
-        throw e;
+        const errMessage = `provider ${rpcUrl}: failed to broadcast tx: ${RedstoneCommon.stringifyError(
+          e
+        )}`;
+        logger(errMessage);
+        throw new Error(errMessage);
       }
     };
 


### PR DESCRIPTION
Now logs look lie this:
<img width="1168" alt="image" src="https://github.com/redstone-finance/redstone-oracles-monorepo/assets/24699136/6a549bc6-fc1a-4358-91b9-ae761f8aa09d">
And I wanted to make them a little bit more friendly cause ethers error doesnt give any more info anyway