### PR TITLE
Fix dead docs link in README.md

### DIFF
--- a/packages/evm-connector/README.md
+++ b/packages/evm-connector/README.md
@@ -9,7 +9,7 @@ The @redstone-finance/evm-connector module implements an alternative design of p
 
 ## Getting started
 
-Please refer to [documentation](https://docs.redstone.finance/docs/smart-contract-devs/get-started/redstone-core)
+Please refer to [documentation](https://docs.redstone.finance/docs/category/getting-started/)
 
 ## 👨‍💻 Development and contributions
 


### PR DESCRIPTION
It previously linked to a /smart-contract-devs/ namespace in your docs which no longer exists